### PR TITLE
divided all the team stuff from normal race gametype

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -920,9 +920,6 @@ void CCharacter::Die(int Killer, int Weapon)
 	GameServer()->m_World.RemoveEntity(this);
 	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
 	GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCID());
-	
-	// reset pickups
-	m_pPlayer->m_ResetPickups = true;
 }
 
 bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)

--- a/src/game/server/entities/flag.cpp
+++ b/src/game/server/entities/flag.cpp
@@ -5,7 +5,7 @@
 #include "../gamemodes/race.h"
 
 CFlag::CFlag(CGameWorld *pGameWorld, int Team, vec2 Pos, CCharacter *pOwner)
-: CEntity(pGameWorld, CGameWorld::ENTTYPE_FLAG, pOwner->GetPlayer()->GetGameTeam())
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_FLAG, Team)
 {
 	m_Team = Team;
 	m_Pos = Pos;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -597,7 +597,7 @@ int IGameController::GetAutoTeam(int NotThisID)
 
 int IGameController::GetAutoGameTeam(int ClientID)
 {
-	return -1;
+	return ClientID;
 }
 
 bool IGameController::CanJoinTeam(int Team, int NotThisID)

--- a/src/game/server/gamemodes/fastcap.h
+++ b/src/game/server/gamemodes/fastcap.h
@@ -1,8 +1,9 @@
 #ifndef GAME_SERVER_GAMEMODES_CTF_H
 #define GAME_SERVER_GAMEMODES_CTF_H
-#include "race.h"
 
-class CGameControllerFC : public CGameControllerRACE
+#include "../no_team_racecontroller.h"
+
+class CGameControllerFC : public CGameControllerNoTeamRace
 {
 public:
 	class CFlag *m_apFlags[2];
@@ -13,7 +14,7 @@ public:
 	bool IsOwnFlagStand(vec2 Pos, int Team);
 	bool IsEnemyFlagStand(vec2 Pos, int Team);
 	
-	virtual bool CanBeMovedOnBalance(int Cid);
+	virtual bool CanBeMovedOnBalance(int ClientID);
 	
 	virtual bool OnEntity(int Index, vec2 Pos);
 	virtual int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon);
@@ -22,8 +23,8 @@ public:
 	
 	virtual bool IsFastCap() { return true; }
 
-	virtual bool OnRaceStart(int ID, float StartAddTime, bool Check);
-	virtual bool OnRaceEnd(int ID, float FinishTime);
+	virtual bool OnRaceStart(int ClientID, float StartAddTime, bool Check);
+	virtual bool OnRaceEnd(int ClientID, float FinishTime);
 	
 	virtual void Snap(int SnappingClient);
 };

--- a/src/game/server/gamemodes/hprace.cpp
+++ b/src/game/server/gamemodes/hprace.cpp
@@ -4,7 +4,7 @@
 #include "hprace.h"
 
 CGameControllerHPRACE::CGameControllerHPRACE(class CGameContext *pGameServer)
-	: CGameControllerRACE(pGameServer)
+	: CGameControllerTeamRace(pGameServer)
 {
 	m_pGameType = "HpRace";
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/server/gamemodes/hprace.h
+++ b/src/game/server/gamemodes/hprace.h
@@ -1,7 +1,7 @@
 
-#include "race.h"
+#include "../team_racecontroller.h"
 
-class CGameControllerHPRACE : public CGameControllerRACE
+class CGameControllerHPRACE : public CGameControllerTeamRace
 {
 private:
 	int m_aPartnerWishes[MAX_CLIENTS];

--- a/src/game/server/gamemodes/race.cpp
+++ b/src/game/server/gamemodes/race.cpp
@@ -3,11 +3,7 @@
 #include <game/server/gamecontext.h>
 
 CGameControllerRACE::CGameControllerRACE(CGameContext *pGameContext)
-	: CRaceController(pGameContext)
+	: CGameControllerNoTeamRace(pGameContext)
 {
 	m_pGameType = "Race";
-}
-
-CGameControllerRACE::~CGameControllerRACE()
-{
 }

--- a/src/game/server/gamemodes/race.h
+++ b/src/game/server/gamemodes/race.h
@@ -2,13 +2,13 @@
 #ifndef GAME_SERVER_GAMEMODES_RACE_H
 #define GAME_SERVER_GAMEMODES_RACE_H
 
-#include <game/server/racecontroller.h>
+#include <game/server/no_team_racecontroller.h>
 
-class CGameControllerRACE : public CRaceController
+class CGameControllerRACE : public CGameControllerNoTeamRace
 {
 public:
 	CGameControllerRACE(class CGameContext *pGameContext);
-	~CGameControllerRACE();
+	~CGameControllerRACE() {}
 };
 
 #endif

--- a/src/game/server/no_team_racecontroller.cpp
+++ b/src/game/server/no_team_racecontroller.cpp
@@ -1,0 +1,263 @@
+/* copyright (c) 2007 rajh, race mod stuff */
+#include <engine/storage.h>
+#include <engine/shared/config.h>
+#include <game/server/entities/character.h>
+#include <game/server/entities/pickup.h>
+#include <game/server/player.h>
+#include <game/server/gamecontext.h>
+#include <game/server/score.h>
+#if defined(CONF_TEERACE)
+#include <game/stream.h>
+#include <game/server/webapp.h>
+#include <engine/external/json/writer.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+#include "no_team_racecontroller.h"
+
+CGameControllerNoTeamRace::CGameControllerNoTeamRace(class CGameContext *pGameServer) : IGameControllerRace(pGameServer)
+{
+	for(int i = 0; i < MAX_CLIENTS; i++)
+		m_aRace[i].Reset();
+}
+
+int CGameControllerNoTeamRace::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
+{
+	int ClientID = pVictim->GetPlayer()->GetCID();
+	m_aRace[ClientID].Reset();
+
+	// remove projectiles if the player is dead to prevent cheating at start
+	if(g_Config.m_SvDeleteGrenadesAfterDeath)
+		for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pEnt; pEnt = pEnt->TypeNext())
+			if(pEnt->Team() == ClientID)
+				pEnt->Reset();
+
+	// respawn pickups
+	for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PICKUP); pEnt; pEnt = pEnt->TypeNext())
+		((CPickup *)pEnt)->Respawn(ClientID);
+
+#if defined(CONF_TEERACE)
+	if(Server()->IsRecording(ClientID))
+		Server()->StopRecord(ClientID);
+
+	if(Server()->IsGhostRecording(ClientID))
+		Server()->StopGhostRecord(ClientID);
+#endif
+
+	return 0;
+}
+
+void CGameControllerNoTeamRace::Tick()
+{
+	IGameController::Tick();
+	DoWincheck();
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		CRaceData *p = &m_aRace[i];
+
+		if(p->m_RaceState == RACE_STARTED && Server()->Tick()-p->m_RefreshTime >= Server()->TickSpeed())
+		{
+			int IntTime = (int)GetTime(i);
+
+			char aBuftime[128];
+			char aTmp[128];
+
+			CNetMsg_Sv_RaceTime Msg;
+			Msg.m_Time = IntTime;
+			Msg.m_Check = 0;
+
+			str_format(aBuftime, sizeof(aBuftime), "Current Time: %d min %d sec", IntTime/60, IntTime%60);
+
+			if(p->m_CpTick != -1 && p->m_CpTick > Server()->Tick())
+			{
+				Msg.m_Check = (int)(p->m_CpDiff*100);
+				str_format(aTmp, sizeof(aTmp), "\nCheckpoint | Diff : %+5.2f", p->m_CpDiff);
+				strcat(aBuftime, aTmp);
+			}
+
+			if(GameServer()->m_apPlayers[i]->m_IsUsingRaceClient)
+				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
+			else
+				GameServer()->SendBroadcast(aBuftime, i);
+
+			p->m_RefreshTime = Server()->Tick();
+		}
+		
+#if defined(CONF_TEERACE)
+		// stop recording at the finish
+		CPlayerData *pBest = GameServer()->Score()->PlayerData(i);
+		if(Server()->IsRecording(i))
+		{
+			if(Server()->Tick() == m_aStopRecordTick[i])
+			{
+				m_aStopRecordTick[i] = -1;
+				Server()->StopRecord(i);
+				continue;
+			}
+			
+			if(m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
+				Server()->StopRecord(i);
+		}
+		
+		// stop ghost if time is bigger then best time
+		if(Server()->IsGhostRecording(i) && m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
+			Server()->StopGhostRecord(i);
+#endif
+	}
+}
+
+bool CGameControllerNoTeamRace::OnCheckpoint(int ClientID, int z)
+{
+	CRaceData *p = &m_aRace[ClientID];
+	CPlayerData *pBest = GameServer()->Score()->PlayerData(ClientID);
+	if(p->m_RaceState != RACE_STARTED)
+		return false;
+
+	p->m_aCpCurrent[z] = GetTime(ClientID);
+
+	if(pBest->m_Time && pBest->m_aCpTime[z] != 0)
+	{
+		p->m_CpDiff = p->m_aCpCurrent[z] - pBest->m_aCpTime[z];
+		p->m_CpTick = Server()->Tick() + Server()->TickSpeed()*2;
+	}
+
+	return true;
+}
+
+bool CGameControllerNoTeamRace::OnRaceStart(int ClientID, float StartAddTime, bool Check)
+{
+	CRaceData *p = &m_aRace[ClientID];
+	CCharacter *pChr = GameServer()->GetPlayerChar(ClientID);
+	if(Check && (pChr->HasWeapon(WEAPON_GRENADE) || pChr->Armor()) && (p->m_RaceState == RACE_FINISHED || p->m_RaceState == RACE_STARTED))
+		return false;
+	
+	p->m_RaceState = RACE_STARTED;
+	p->m_StartTime = Server()->Tick();
+	p->m_RefreshTime = Server()->Tick();
+	p->m_StartAddTime = StartAddTime;
+
+	if(p->m_RaceState != RACE_NONE)
+	{
+		// reset pickups
+		if(!pChr->HasWeapon(WEAPON_GRENADE))
+			for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PICKUP); pEnt; pEnt = pEnt->TypeNext())
+				((CPickup *)pEnt)->Respawn(ClientID);
+	}
+
+#if defined(CONF_TEERACE)
+	if(Server()->GetUserID(ClientID) > 0 && GameServer()->Webapp()->CurrentMap()->m_ID > -1 && !Server()->IsGhostRecording(ClientID))
+		Server()->StartGhostRecord(ClientID, pChr->GetPlayer()->m_TeeInfos.m_SkinName, pChr->GetPlayer()->m_TeeInfos.m_UseCustomColor, pChr->GetPlayer()->m_TeeInfos.m_ColorBody, pChr->GetPlayer()->m_TeeInfos.m_ColorFeet);
+#endif
+
+	return true;
+}
+
+bool CGameControllerNoTeamRace::OnRaceEnd(int ClientID, float FinishTime)
+{
+	CRaceData *p = &m_aRace[ClientID];
+	CPlayerData *pBest = GameServer()->Score()->PlayerData(ClientID);
+	if(p->m_RaceState != RACE_STARTED)
+		return false;
+
+	p->m_RaceState = RACE_FINISHED;
+
+	// add the time from the start
+	FinishTime += p->m_StartAddTime;
+	
+	GameServer()->m_apPlayers[ClientID]->m_Score = max(-(int)FinishTime, GameServer()->m_apPlayers[ClientID]->m_Score);
+
+	float Improved = FinishTime - pBest->m_Time;
+	bool NewRecord = pBest->Check(FinishTime, p->m_aCpCurrent);
+
+	// save the score
+	if(str_comp_num(Server()->ClientName(ClientID), "nameless tee", 12) != 0 && NewRecord)
+	{
+		GameServer()->Score()->SaveScore(ClientID);
+		if(GameServer()->Score()->CheckRecord(ClientID) && g_Config.m_SvShowTimes)
+			GameServer()->SendRecord(-1);
+	}
+
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "%s finished in: %d minute(s) %6.3f second(s)", Server()->ClientName(ClientID), (int)FinishTime/60, fmod(FinishTime,60));
+	if(!g_Config.m_SvShowTimes)
+		GameServer()->SendChatTarget(ClientID, aBuf);
+	else
+		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+
+	if(Improved < 0)
+	{
+		str_format(aBuf, sizeof(aBuf), "New record: %6.3f second(s) better", Improved);
+		if(!g_Config.m_SvShowTimes)
+			GameServer()->SendChatTarget(ClientID, aBuf);
+		else
+			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+	}
+	
+#if defined(CONF_TEERACE)	
+	// post to webapp
+	if(GameServer()->Webapp())
+	{
+		CWebRunData *pUserData = new CWebRunData();
+		pUserData->m_UserID = Server()->GetUserID(ClientID);
+		pUserData->m_ClientID = ClientID;
+		pUserData->m_Tick = -1;
+
+		if(NewRecord && Server()->GetUserID(ClientID) > 0)
+		{
+			// set demo and ghost so that it is saved
+			Server()->SaveGhostDemo(ClientID);
+			pUserData->m_Tick = Server()->Tick();
+		}
+
+		if(GameServer()->Webapp()->CurrentMap()->m_ID > -1)
+		{
+			Json::Value Run;
+			Json::FastWriter Writer;
+
+			char aBuf[1024];
+			Run["map_id"] = GameServer()->Webapp()->CurrentMap()->m_ID;
+			Run["map_crc"] = GameServer()->Webapp()->CurrentMap()->m_aCrc;
+			Run["user_id"] = Server()->GetUserID(ClientID);
+			// TODO: take this out after 0.6 release
+			str_copy(aBuf, Server()->ClientName(ClientID), MAX_NAME_LENGTH);
+			str_sanitize_strong(aBuf);
+			Run["nickname"] = aBuf;
+			if(Server()->ClientClan(ClientID)[0])
+				Run["clan"] = Server()->ClientClan(ClientID);
+			str_format(aBuf, sizeof(aBuf), "%.3f", FinishTime);
+			Run["time"] = aBuf;
+			float *pCpTime = p->m_aCpCurrent;
+			str_format(aBuf, sizeof(aBuf), "%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f;%.3f",
+				pCpTime[0], pCpTime[1], pCpTime[2], pCpTime[3], pCpTime[4], pCpTime[5], pCpTime[6], pCpTime[7], pCpTime[8], pCpTime[9],
+				pCpTime[10], pCpTime[11], pCpTime[12], pCpTime[13], pCpTime[14], pCpTime[15], pCpTime[16], pCpTime[17], pCpTime[18], pCpTime[19],
+				pCpTime[20], pCpTime[21], pCpTime[22], pCpTime[23], pCpTime[24], pCpTime[25]);
+			Run["checkpoints"] = aBuf;
+
+			std::string Json = Writer.write(Run);
+
+			str_format(aBuf, sizeof(aBuf), CServerWebapp::POST, GameServer()->Webapp()->ApiPath(), "runs/new/",
+				GameServer()->Webapp()->ServerIP(), GameServer()->Webapp()->ApiKey(), Json.length(), Json.c_str());
+			GameServer()->Webapp()->SendRequest(aBuf, WEB_RUN_POST, new CBufferStream(), pUserData);
+		}
+		
+		// higher run count
+		GameServer()->Webapp()->CurrentMap()->m_RunCount++;
+	}
+	
+	// set stop record tick
+	if(Server()->IsRecording(ClientID))
+		m_aStopRecordTick[ClientID] = Server()->Tick()+Server()->TickSpeed();
+	
+	// stop ghost record
+	if(Server()->IsGhostRecording(ClientID))
+		Server()->StopGhostRecord(ClientID, FinishTime);
+#endif
+
+	return true;
+}
+
+float CGameControllerNoTeamRace::GetTime(int ClientID)
+{
+	return (float)(Server()->Tick()-m_aRace[ClientID].m_StartTime)/((float)Server()->TickSpeed());
+}

--- a/src/game/server/no_team_racecontroller.h
+++ b/src/game/server/no_team_racecontroller.h
@@ -1,0 +1,49 @@
+/* copyright (c) 2007 rajh and gregwar. Score stuff */
+#ifndef GAME_SERVER_NORACETEAMCONTROLLER_H
+#define GAME_SERVER_NORACETEAMCONTROLLER_H
+
+#include "gamecontext.h"
+#include "racecontroller.h"
+
+class CGameControllerNoTeamRace : public IGameControllerRace
+{
+public:
+
+	struct CRaceData
+	{
+		int m_RaceState;
+		int m_StartTime;
+		int m_RefreshTime;
+
+		float m_aCpCurrent[25];
+		int m_CpTick;
+		float m_CpDiff;
+		
+		float m_StartAddTime;
+
+		void Reset()
+		{
+			m_RaceState = RACE_NONE;
+			m_StartTime = -1;
+			m_RefreshTime = -1;
+			mem_zero(m_aCpCurrent, sizeof(m_aCpCurrent));
+			m_CpTick = -1;
+			m_CpDiff = 0;
+			m_StartAddTime = 0.0f;
+		}
+	} m_aRace[MAX_CLIENTS];
+	
+	CGameControllerNoTeamRace(class CGameContext *pGameServer);
+	virtual ~CGameControllerNoTeamRace() {}
+
+	virtual void Tick();
+	virtual int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon);
+
+	virtual bool OnCheckpoint(int ClientID, int z);
+	virtual bool OnRaceStart(int ClientID, float StartAddTime, bool Check=true);
+	virtual bool OnRaceEnd(int ClientID, float FinishTime);
+
+	virtual float GetTime(int ClientID);
+};
+
+#endif

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -33,7 +33,6 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team, int GameTeam
 	else
 		m_ShowOthers = true;
 		
-	m_ResetPickups = true;
 	m_IsUsingRaceClient = false;
 
 #if defined(CONF_TEERACE)
@@ -123,10 +122,6 @@ void CPlayer::Tick()
 	}
 	else if(m_Spawning && m_RespawnTick <= Server()->Tick())
 		TryRespawn();
-	
-	// reset PickupReset
-	if(m_ResetPickups && GetCharacter())
-		m_ResetPickups = false;
 }
 
 void CPlayer::PostTick()

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -101,7 +101,6 @@ public:
 		int m_Max;
 	} m_Latency;
 
-	bool m_ResetPickups;
 	bool m_ShowOthers;
 	
 	bool m_IsUsingRaceClient;

--- a/src/game/server/racecontroller.cpp
+++ b/src/game/server/racecontroller.cpp
@@ -1,41 +1,27 @@
 /* copyright (c) 2007 rajh, race mod stuff */
 
-#include <engine/storage.h>
 #include <engine/shared/config.h>
-
-#include <game/server/gameworld.h>
-#include <game/server/entities/character.h>
-#include <game/server/entities/pickup.h>
-#include <game/server/player.h>
-#include <game/server/gamecontext.h>
-#include <game/server/score.h>
-
-#if defined(CONF_TEERACE)
-#include <game/server/webapp.h>
-#endif
-
 #include "racecontroller.h"
 
-CRaceController::CRaceController(class CGameContext *pGameServer) : IGameController(pGameServer)
+IGameControllerRace::IGameControllerRace(class CGameContext *pGameServer) : IGameController(pGameServer)
 {
+	m_pGameType = "";
 	m_pTeleporter = 0;
 	
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		m_aRace[i].Reset();
-		m_aPlayerRace[i].Reset();
 #if defined(CONF_TEERACE)
 		m_aStopRecordTick[i] = -1;
 #endif
 	}
 }
 
-CRaceController::~CRaceController()
+IGameControllerRace::~IGameControllerRace()
 {
 	delete[] m_pTeleporter;
 }
 
-void CRaceController::InitTeleporter()
+void IGameControllerRace::InitTeleporter()
 {
 	int ArraySize = 0;
 	if(GameServer()->Collision()->Layers()->TeleLayer())
@@ -65,75 +51,7 @@ void CRaceController::InitTeleporter()
 	}
 }
 
-int CRaceController::GetAutoGameTeam(int ClientID)
-{
-	return ClientID;
-}
-
-int CRaceController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
-{
-	int ClientID = pVictim->GetPlayer()->GetCID();
-	int GameTeam = pVictim->GetPlayer()->GetGameTeam();
-
-	if(m_aRace[GameTeam].m_RaceState == RACE_NONE)
-		m_aPlayerRace[ClientID].m_State = RACE_NONE;
-	else
-		m_aPlayerRace[ClientID].m_State = RACE_TEAM_STARTED;
-
-	bool Reset = 1;
-	bool AllDead = 1;
-
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetGameTeam() == GameTeam)
-		{
-			if(GameServer()->m_apPlayers[i]->GetCharacter() &&  GameServer()->m_apPlayers[i]->GetCharacter()->IsAlive())
-				AllDead = 0;
-			if(m_aPlayerRace[i].m_State != m_aPlayerRace[ClientID].m_State)
-				Reset = 0;
-			if(!Reset && !AllDead)
-				break;
-		}
-
-	if(Reset)
-	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
-			if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetGameTeam() == GameTeam)
-				m_aPlayerRace[i].m_State = RACE_NONE;
-
-		m_aRace[GameTeam].m_RaceState = RACE_NONE;
-	}
-
-	if(AllDead)
-	{
-		// remove projectiles if the player is dead to prevent cheating at start
-		if(g_Config.m_SvDeleteGrenadesAfterDeath)
-		{
-			for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pEnt; pEnt = pEnt->TypeNext())
-				if(pEnt->Team() == GameTeam)
-					pEnt->Reset();
-
-			for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
-				if(pEnt->Team() == GameTeam)
-					pEnt->Reset();
-		}
-
-		// respawn pickups
-		for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PICKUP); pEnt; pEnt = pEnt->TypeNext())
-			((CPickup *)pEnt)->Respawn(GameTeam);
-
-#if defined(CONF_TEERACE)
-		if(Server()->IsRecording(ClientID))
-			Server()->StopRecord(ClientID);
-	
-		if(Server()->IsGhostRecording(ClientID))
-			Server()->StopGhostRecord(ClientID);
-#endif
-	}
-
-	return 0;
-}
-
-void CRaceController::DoWincheck()
+void IGameControllerRace::DoWincheck()
 {
 	if(m_GameOverTick == -1 && !m_Warmup)
 	{
@@ -141,226 +59,3 @@ void CRaceController::DoWincheck()
 			EndRound();
 	}
 }
-
-void CRaceController::Tick()
-{
-	IGameController::Tick();
-	DoWincheck();
-
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(!GameServer()->m_apPlayers[i])
-			continue;
-
-		CRaceData *p = &m_aRace[GameServer()->m_apPlayers[i]->GetGameTeam()];
-
-		if((p->m_RaceState == RACE_STARTED) && Server()->Tick()-p->m_RefreshTime >= Server()->TickSpeed())
-		{
-			int IntTime = (int)GetTime(i);
-
-			char aBuftime[128];
-			char aTmp[128];
-
-			CNetMsg_Sv_RaceTime Msg;
-			Msg.m_Time = IntTime;
-			Msg.m_Check = 0;
-
-			str_format(aBuftime, sizeof(aBuftime), "Current Time: %d min %d sec", IntTime/60, IntTime%60);
-
-			if(p->m_CpTick != -1 && p->m_CpTick > Server()->Tick())
-			{
-				Msg.m_Check = (int)(m_aPlayerRace[i].m_CpDiff*100);
-				str_format(aTmp, sizeof(aTmp), "\nCheckpoint | Diff : %+5.2f", m_aPlayerRace[i].m_CpDiff);
-				str_append(aBuftime, aTmp, sizeof(aBuftime));
-			}
-
-			if(GameServer()->m_apPlayers[i]->m_IsUsingRaceClient)
-				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
-			else
-				GameServer()->SendBroadcast(aBuftime, i);
-		}
-
-#if defined(CONF_TEERACE)
-		// stop recording at the finish
-		CPlayerData *pBest = GameServer()->Score()->PlayerData(i);
-		if(Server()->IsRecording(i))
-		{
-			if(Server()->Tick() == m_aStopRecordTick[i])
-			{
-				m_aStopRecordTick[i] = -1;
-				Server()->StopRecord(i);
-				continue;
-			}
-			
-			if(m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
-				Server()->StopRecord(i);
-		}
-		
-		// stop ghost if time is bigger then best time
-		if(Server()->IsGhostRecording(i) && m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
-			Server()->StopGhostRecord(i);
-#endif
-	}
-
-	for(int i = 0; i < 16; i++)
-	{
-		if(Server()->Tick()-m_aRace[i].m_RefreshTime >= Server()->TickSpeed())
-			m_aRace[i].m_RefreshTime = Server()->Tick();
-	}
-		
-}
-
-bool CRaceController::OnCheckpoint(int ID, int z)
-{
-	int GameTeam = GameServer()->m_apPlayers[ID]->GetGameTeam();
-	CRaceData *p = &m_aRace[GameTeam];
-
-	if(p->m_RaceState != RACE_STARTED)
-		return false;
-
-	p->m_aCpCurrent[z] = GetTime(GameTeam);
-
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
-			continue;
-
-		CPlayerData *pBest = GameServer()->Score()->PlayerData(ID);
-
-		if(pBest->m_Time && pBest->m_aCpTime[z] != 0)
-		{
-			m_aPlayerRace[i].m_CpDiff = p->m_aCpCurrent[z] - pBest->m_aCpTime[z];
-			p->m_CpTick = Server()->Tick() + Server()->TickSpeed()*2;
-		}
-	}
-
-	return true;
-}
-
-bool CRaceController::OnRaceStart(int ID, float StartAddTime, bool Check)
-{
-	int GameTeam = GameServer()->m_apPlayers[ID]->GetGameTeam();
-	CRaceData *p = &m_aRace[GameTeam];
-
-	if(p->m_RaceState != RACE_FINISHED)
-		m_aPlayerRace[ID].m_State = RACE_STARTED;
-
-	if(p->m_RaceState != RACE_NONE)
-		return false;
-
-	p->m_RaceState = RACE_STARTED;
-	p->m_StartTime = Server()->Tick();
-	p->m_RefreshTime = Server()->Tick();
-	p->m_StartAddTime = StartAddTime;
-
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
-			continue;
-
-		m_aPlayerRace[i].m_State = (i == ID) ? RACE_STARTED : RACE_TEAM_STARTED;
-	}
-
-#if defined(CONF_TEERACE)
-	if(Server()->GetUserID(ID) > 0 && GameServer()->Webapp()->CurrentMap()->m_ID > -1 && !Server()->IsGhostRecording(ID))
-		Server()->StartGhostRecord(ID, pChr->GetPlayer()->m_TeeInfos.m_SkinName, pChr->GetPlayer()->m_TeeInfos.m_UseCustomColor, pChr->GetPlayer()->m_TeeInfos.m_ColorBody, pChr->GetPlayer()->m_TeeInfos.m_ColorFeet);
-#endif
-
-	return true;
-}
-
-bool CRaceController::OnRaceEnd(int ID, float FinishTime)
-{ 
-	int GameTeam = GameServer()->m_apPlayers[ID]->GetGameTeam();
-	CRaceData *p = &m_aRace[GameTeam];
-
-	if(p->m_RaceState != RACE_STARTED)
-		return false;
-
-	p->m_RaceState = RACE_FINISHED;
-
-	for(int i = 0;  i < MAX_CLIENTS; i++)
-	{
-		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
-			continue;
-
-		m_aPlayerRace[i].m_State = RACE_FINISHED;
-
-		CPlayerData *pBest = GameServer()->Score()->PlayerData(i);
-
-		// add the time from the start
-		FinishTime += p->m_StartAddTime;
-	
-		GameServer()->m_apPlayers[i]->m_Score = max(-(int)FinishTime, GameServer()->m_apPlayers[i]->m_Score);
-
-		float Improved = FinishTime - pBest->m_Time;
-		bool NewRecord = pBest->Check(FinishTime, p->m_aCpCurrent);
-
-		// save the score
-		if(str_comp_num(Server()->ClientName(i), "nameless tee", 12) != 0 && NewRecord)
-		{
-			GameServer()->Score()->SaveScore(i);
-			if(GameServer()->Score()->CheckRecord(i) && g_Config.m_SvShowTimes)
-				GameServer()->SendRecord(-1);
-		}
-
-		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "%s finished in: %d minute(s) %6.3f second(s)", Server()->ClientName(i), (int)FinishTime / 60, fmod(FinishTime, 60));
-		if(!g_Config.m_SvShowTimes)
-			GameServer()->SendChatTarget(i, aBuf);
-		else
-			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
-
-		if(Improved < 0)
-		{
-			str_format(aBuf, sizeof(aBuf), "New record: %6.3f second(s) better", Improved);
-			if(!g_Config.m_SvShowTimes)
-				GameServer()->SendChatTarget(i, aBuf);
-			else
-				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
-		}
-	}
-	
-#if defined(CONF_TEERACE)	
-	// post to webapp
-	if(GameServer()->Webapp())
-	{
-		CWebRun::CParam *pParams = new CWebRun::CParam();
-		pParams->m_UserID = Server()->GetUserID(ID);
-		pParams->m_ClientID = ID;
-		str_copy(pParams->m_aName, Server()->ClientName(ID), MAX_NAME_LENGTH);
-		str_copy(pParams->m_aClan, Server()->ClientClan(ID), MAX_CLAN_LENGTH);
-		pParams->m_Time = FinishTime;
-		mem_copy(pParams->m_aCpTime, p->m_aCpCurrent, sizeof(pParams->m_aCpTime));
-		
-		if(NewRecord && Server()->GetUserID(ID) > 0)
-		{
-			// set demo and ghost so that it is saved
-			Server()->SaveGhostDemo(ID);
-			pParams->m_Tick = Server()->Tick();
-		}
-		
-		if(GameServer()->Webapp()->CurrentMap()->m_ID > -1)
-			GameServer()->Webapp()->AddJob(CWebRun::Post, pParams);
-		
-		// higher run count
-		GameServer()->Webapp()->CurrentMap()->m_RunCount++;
-	}
-	
-	// set stop record tick
-	if(Server()->IsRecording(ID))
-		m_aStopRecordTick[ID] = Server()->Tick()+Server()->TickSpeed();
-	
-	// stop ghost record
-	if(Server()->IsGhostRecording(ID))
-		Server()->StopGhostRecord(ID, FinishTime);
-#endif
-
-	return true;
-}
-
-float CRaceController::GetTime(int ID)
-{
-	return (float)(Server()->Tick()-m_aRace[GameServer()->m_apPlayers[ID]->GetGameTeam()].m_StartTime)/((float)Server()->TickSpeed());
-}
-

--- a/src/game/server/racecontroller.h
+++ b/src/game/server/racecontroller.h
@@ -1,10 +1,11 @@
 /* copyright (c) 2007 rajh and gregwar. Score stuff */
-#ifndef GAME_SERVER_RACECONTROLLER_H
-#define GAME_SERVER_RACECONTROLLER_H
+#ifndef GAME_SERVER_GAMEMODES_INTERFACE_RACE_H
+#define GAME_SERVER_GAMEMODES_INTERFACE_RACE_H
 
-#include "gamecontroller.h"
+#include <game/server/gamecontext.h>
+#include <game/server/gamecontroller.h>
 
-class CRaceController : public IGameController
+class IGameControllerRace : public IGameController
 {
 public:
 	enum
@@ -12,70 +13,28 @@ public:
 		RACE_NONE = 0,
 		RACE_STARTED,
 		RACE_FINISHED,
-		RACE_TEAM_STARTED,
 	};
-
-	struct CRaceData
-	{
-		int m_RaceState;
-		int m_StartTime;
-		int m_RefreshTime;
-
-		float m_aCpCurrent[25];
-		int m_CpTick;
-
-		float m_StartAddTime;
-
-		void Reset()
-		{
-			m_RaceState = RACE_NONE;
-			m_StartTime = -1;
-			m_RefreshTime = -1;
-			for(unsigned i = 0; i < sizeof(m_aCpCurrent) / sizeof(m_aCpCurrent[0]); i++)
-				m_aCpCurrent[i] = 0.0f;
-			m_CpTick = -1;
-			m_StartAddTime = 0.0f;
-		}
-	} m_aRace[MAX_TEAMS];
-
-	struct CPlayerRaceData
-	{
-		int m_State;
-		float m_CpDiff;
-
-		void Reset()
-		{
-			m_State = RACE_NONE;
-			m_CpDiff = 0.0f;
-		}
-	} m_aPlayerRace[MAX_CLIENTS];
-
-	CRaceController(class CGameContext *pGameServer);
-	~CRaceController();
-
-	virtual bool FakeCollisionTune() const { return true; }
-	virtual bool FakeHookTune() const { return true; }
+	
+	IGameControllerRace(class CGameContext *pGameServer);
+	virtual ~IGameControllerRace();
 	
 	vec2 *m_pTeleporter;
 	
 #if defined(CONF_TEERACE)
 	int m_aStopRecordTick[MAX_CLIENTS];
 #endif
-
+	
 	void InitTeleporter();
 
 	virtual void DoWincheck();
-	virtual void Tick();
-	virtual int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon);
+	virtual void Tick() = 0;
+	virtual int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon) = 0;
 
-	virtual bool OnCheckpoint(int ID, int z);
-	virtual bool OnRaceStart(int ID, float StartAddTime, bool Check=true);
-	virtual bool OnRaceEnd(int ID, float FinishTime);
+	virtual bool OnCheckpoint(int ClientID, int z) = 0;
+	virtual bool OnRaceStart(int ClientID, float StartAddTime, bool Check=true) = 0;
+	virtual bool OnRaceEnd(int ClientID, float FinishTime) = 0;
 
-	virtual int GetAutoGameTeam(int ClientID);
-
-	float GetTime(int ID);
+	virtual float GetTime(int ClientID) = 0;
 };
 
 #endif
-

--- a/src/game/server/team_racecontroller.cpp
+++ b/src/game/server/team_racecontroller.cpp
@@ -1,0 +1,317 @@
+/* copyright (c) 2007 rajh, race mod stuff */
+
+#include <engine/storage.h>
+#include <engine/shared/config.h>
+
+#include <game/server/gameworld.h>
+#include <game/server/entities/character.h>
+#include <game/server/entities/pickup.h>
+#include <game/server/player.h>
+#include <game/server/gamecontext.h>
+#include <game/server/score.h>
+
+#if defined(CONF_TEERACE)
+#include <game/server/webapp.h>
+#endif
+
+#include "team_racecontroller.h"
+
+CGameControllerTeamRace::CGameControllerTeamRace(class CGameContext *pGameServer) : IGameControllerRace(pGameServer)
+{
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		m_aRace[i].Reset();
+		m_aPlayerRace[i].Reset();
+	}
+}
+
+int CGameControllerTeamRace::GetAutoGameTeam(int ClientID)
+{
+	return ClientID;
+}
+
+int CGameControllerTeamRace::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
+{
+	int ClientID = pVictim->GetPlayer()->GetCID();
+	int GameTeam = pVictim->GetPlayer()->GetGameTeam();
+
+	if(m_aRace[GameTeam].m_RaceState == RACE_NONE)
+		m_aPlayerRace[ClientID].m_State = RACE_NONE;
+	else
+		m_aPlayerRace[ClientID].m_State = RACE_TEAM_STARTED;
+
+	bool Reset = 1;
+	bool AllDead = 1;
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+		if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetGameTeam() == GameTeam)
+		{
+			if(GameServer()->m_apPlayers[i]->GetCharacter() &&  GameServer()->m_apPlayers[i]->GetCharacter()->IsAlive())
+				AllDead = 0;
+			if(m_aPlayerRace[i].m_State != m_aPlayerRace[ClientID].m_State)
+				Reset = 0;
+			if(!Reset && !AllDead)
+				break;
+		}
+
+	if(Reset)
+	{
+		for(int i = 0; i < MAX_CLIENTS; i++)
+			if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetGameTeam() == GameTeam)
+				m_aPlayerRace[i].m_State = RACE_NONE;
+
+		m_aRace[GameTeam].m_RaceState = RACE_NONE;
+	}
+
+	if(AllDead)
+	{
+		// remove projectiles if the player is dead to prevent cheating at start
+		if(g_Config.m_SvDeleteGrenadesAfterDeath)
+		{
+			for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pEnt; pEnt = pEnt->TypeNext())
+				if(pEnt->Team() == GameTeam)
+					pEnt->Reset();
+
+			for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
+				if(pEnt->Team() == GameTeam)
+					pEnt->Reset();
+		}
+
+		// respawn pickups
+		for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PICKUP); pEnt; pEnt = pEnt->TypeNext())
+			((CPickup *)pEnt)->Respawn(GameTeam);
+
+#if defined(CONF_TEERACE)
+		if(Server()->IsRecording(ClientID))
+			Server()->StopRecord(ClientID);
+	
+		if(Server()->IsGhostRecording(ClientID))
+			Server()->StopGhostRecord(ClientID);
+#endif
+	}
+
+	return 0;
+}
+
+void CGameControllerTeamRace::Tick()
+{
+	IGameController::Tick();
+	DoWincheck();
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(!GameServer()->m_apPlayers[i])
+			continue;
+
+		CRaceData *p = &m_aRace[GameServer()->m_apPlayers[i]->GetGameTeam()];
+
+		if((p->m_RaceState == RACE_STARTED) && Server()->Tick()-p->m_RefreshTime >= Server()->TickSpeed())
+		{
+			int IntTime = (int)GetTime(i);
+
+			char aBuftime[128];
+			char aTmp[128];
+
+			CNetMsg_Sv_RaceTime Msg;
+			Msg.m_Time = IntTime;
+			Msg.m_Check = 0;
+
+			str_format(aBuftime, sizeof(aBuftime), "Current Time: %d min %d sec", IntTime/60, IntTime%60);
+
+			if(p->m_CpTick != -1 && p->m_CpTick > Server()->Tick())
+			{
+				Msg.m_Check = (int)(m_aPlayerRace[i].m_CpDiff*100);
+				str_format(aTmp, sizeof(aTmp), "\nCheckpoint | Diff : %+5.2f", m_aPlayerRace[i].m_CpDiff);
+				str_append(aBuftime, aTmp, sizeof(aBuftime));
+			}
+
+			if(GameServer()->m_apPlayers[i]->m_IsUsingRaceClient)
+				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
+			else
+				GameServer()->SendBroadcast(aBuftime, i);
+		}
+
+#if defined(CONF_TEERACE)
+		// stop recording at the finish
+		CPlayerData *pBest = GameServer()->Score()->PlayerData(i);
+		if(Server()->IsRecording(i))
+		{
+			if(Server()->Tick() == m_aStopRecordTick[i])
+			{
+				m_aStopRecordTick[i] = -1;
+				Server()->StopRecord(i);
+				continue;
+			}
+			
+			if(m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
+				Server()->StopRecord(i);
+		}
+		
+		// stop ghost if time is bigger then best time
+		if(Server()->IsGhostRecording(i) && m_aRace[i].m_RaceState == RACE_STARTED && pBest->m_Time > 0 && pBest->m_Time < GetTime(i))
+			Server()->StopGhostRecord(i);
+#endif
+	}
+
+	for(int i = 0; i < MAX_TEAMS; i++)
+	{
+		if(Server()->Tick()-m_aRace[i].m_RefreshTime >= Server()->TickSpeed())
+			m_aRace[i].m_RefreshTime = Server()->Tick();
+	}
+		
+}
+
+bool CGameControllerTeamRace::OnCheckpoint(int ClientID, int z)
+{
+	int GameTeam = GameServer()->m_apPlayers[ClientID]->GetGameTeam();
+	CRaceData *p = &m_aRace[GameTeam];
+
+	if(p->m_RaceState != RACE_STARTED)
+		return false;
+
+	p->m_aCpCurrent[z] = GetTime(GameTeam);
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
+			continue;
+
+		CPlayerData *pBest = GameServer()->Score()->PlayerData(ClientID);
+
+		if(pBest->m_Time && pBest->m_aCpTime[z] != 0)
+		{
+			m_aPlayerRace[i].m_CpDiff = p->m_aCpCurrent[z] - pBest->m_aCpTime[z];
+			p->m_CpTick = Server()->Tick() + Server()->TickSpeed()*2;
+		}
+	}
+
+	return true;
+}
+
+bool CGameControllerTeamRace::OnRaceStart(int ClientID, float StartAddTime, bool Check)
+{
+	int GameTeam = GameServer()->m_apPlayers[ClientID]->GetGameTeam();
+	CRaceData *p = &m_aRace[GameTeam];
+
+	if(p->m_RaceState != RACE_FINISHED)
+		m_aPlayerRace[ClientID].m_State = RACE_STARTED;
+
+	if(p->m_RaceState != RACE_NONE)
+		return false;
+
+	p->m_RaceState = RACE_STARTED;
+	p->m_StartTime = Server()->Tick();
+	p->m_RefreshTime = Server()->Tick();
+	p->m_StartAddTime = StartAddTime;
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
+			continue;
+
+		m_aPlayerRace[i].m_State = (i == ClientID) ? RACE_STARTED : RACE_TEAM_STARTED;
+	}
+
+#if defined(CONF_TEERACE)
+	if(Server()->GetUserID(ClientID) > 0 && GameServer()->Webapp()->CurrentMap()->m_ID > -1 && !Server()->IsGhostRecording(ClientID))
+		Server()->StartGhostRecord(ClientID, pChr->GetPlayer()->m_TeeInfos.m_SkinName, pChr->GetPlayer()->m_TeeInfos.m_UseCustomColor, pChr->GetPlayer()->m_TeeInfos.m_ColorBody, pChr->GetPlayer()->m_TeeInfos.m_ColorFeet);
+#endif
+
+	return true;
+}
+
+bool CGameControllerTeamRace::OnRaceEnd(int ClientID, float FinishTime)
+{ 
+	int GameTeam = GameServer()->m_apPlayers[ClientID]->GetGameTeam();
+	CRaceData *p = &m_aRace[GameTeam];
+
+	if(p->m_RaceState != RACE_STARTED)
+		return false;
+
+	p->m_RaceState = RACE_FINISHED;
+
+	for(int i = 0;  i < MAX_CLIENTS; i++)
+	{
+		if(!GameServer()->m_apPlayers[i] || GameServer()->m_apPlayers[i]->GetGameTeam() != GameTeam)
+			continue;
+
+		m_aPlayerRace[i].m_State = RACE_FINISHED;
+
+		CPlayerData *pBest = GameServer()->Score()->PlayerData(i);
+
+		// add the time from the start
+		FinishTime += p->m_StartAddTime;
+	
+		GameServer()->m_apPlayers[i]->m_Score = max(-(int)FinishTime, GameServer()->m_apPlayers[i]->m_Score);
+
+		float Improved = FinishTime - pBest->m_Time;
+		bool NewRecord = pBest->Check(FinishTime, p->m_aCpCurrent);
+
+		// save the score
+		if(str_comp_num(Server()->ClientName(i), "nameless tee", 12) != 0 && NewRecord)
+		{
+			GameServer()->Score()->SaveScore(i);
+			if(GameServer()->Score()->CheckRecord(i) && g_Config.m_SvShowTimes)
+				GameServer()->SendRecord(-1);
+		}
+
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "%s finished in: %d minute(s) %6.3f second(s)", Server()->ClientName(i), (int)FinishTime / 60, fmod(FinishTime, 60));
+		if(!g_Config.m_SvShowTimes)
+			GameServer()->SendChatTarget(i, aBuf);
+		else
+			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+
+		if(Improved < 0)
+		{
+			str_format(aBuf, sizeof(aBuf), "New record: %6.3f second(s) better", Improved);
+			if(!g_Config.m_SvShowTimes)
+				GameServer()->SendChatTarget(i, aBuf);
+			else
+				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+		}
+	}
+	
+#if defined(CONF_TEERACE)	
+	// post to webapp
+	if(GameServer()->Webapp())
+	{
+		CWebRun::CParam *pParams = new CWebRun::CParam();
+		pParams->m_UserID = Server()->GetUserID(ClientID);
+		pParams->m_ClientID = ClientID;
+		str_copy(pParams->m_aName, Server()->ClientName(ClientID), MAX_NAME_LENGTH);
+		str_copy(pParams->m_aClan, Server()->ClientClan(ClientID), MAX_CLAN_LENGTH);
+		pParams->m_Time = FinishTime;
+		mem_copy(pParams->m_aCpTime, p->m_aCpCurrent, sizeof(pParams->m_aCpTime));
+		
+		if(NewRecord && Server()->GetUserID(ClientID) > 0)
+		{
+			// set demo and ghost so that it is saved
+			Server()->SaveGhostDemo(ClientID);
+			pParams->m_Tick = Server()->Tick();
+		}
+		
+		if(GameServer()->Webapp()->CurrentMap()->m_ID > -1)
+			GameServer()->Webapp()->AddJob(CWebRun::Post, pParams);
+		
+		// higher run count
+		GameServer()->Webapp()->CurrentMap()->m_RunCount++;
+	}
+	
+	// set stop record tick
+	if(Server()->IsRecording(ClientID))
+		m_aStopRecordTick[ClientID] = Server()->Tick()+Server()->TickSpeed();
+	
+	// stop ghost record
+	if(Server()->IsGhostRecording(ClientID))
+		Server()->StopGhostRecord(ClientID, FinishTime);
+#endif
+
+	return true;
+}
+
+float CGameControllerTeamRace::GetTime(int ClientID)
+{
+	return (float)(Server()->Tick()-m_aRace[GameServer()->m_apPlayers[ClientID]->GetGameTeam()].m_StartTime)/((float)Server()->TickSpeed());
+}
+

--- a/src/game/server/team_racecontroller.h
+++ b/src/game/server/team_racecontroller.h
@@ -1,0 +1,69 @@
+/* copyright (c) 2007 rajh and gregwar. Score stuff */
+#ifndef GAME_SERVER_RACETEAMCONTROLLER_H
+#define GAME_SERVER_RACETEAMCONTROLLER_H
+
+#include "racecontroller.h"
+
+class CGameControllerTeamRace : public IGameControllerRace
+{
+public:
+	enum
+	{
+		RACE_TEAM_STARTED = 3,
+	};
+
+	struct CRaceData
+	{
+		int m_RaceState;
+		int m_StartTime;
+		int m_RefreshTime;
+
+		float m_aCpCurrent[25];
+		int m_CpTick;
+
+		float m_StartAddTime;
+
+		void Reset()
+		{
+			m_RaceState = RACE_NONE;
+			m_StartTime = -1;
+			m_RefreshTime = -1;
+			for(unsigned i = 0; i < sizeof(m_aCpCurrent) / sizeof(m_aCpCurrent[0]); i++)
+				m_aCpCurrent[i] = 0.0f;
+			m_CpTick = -1;
+			m_StartAddTime = 0.0f;
+		}
+	} m_aRace[MAX_TEAMS];
+
+	struct CPlayerRaceData
+	{
+		int m_State;
+		float m_CpDiff;
+
+		void Reset()
+		{
+			m_State = RACE_NONE;
+			m_CpDiff = 0.0f;
+		}
+	} m_aPlayerRace[MAX_CLIENTS];
+
+	CGameControllerTeamRace(class CGameContext *pGameServer);
+	virtual ~CGameControllerTeamRace() {}
+
+	virtual bool FakeCollisionTune() const { return true; }
+	virtual bool FakeHookTune() const { return true; }
+
+	virtual void Tick();
+	virtual int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon);
+
+	virtual bool OnCheckpoint(int ClientID, int z);
+	virtual bool OnRaceStart(int ClientID, float StartAddTime, bool Check=true);
+	virtual bool OnRaceEnd(int ClientID, float FinishTime);
+
+	virtual int GetAutoGameTeam(int ClientID);
+
+	virtual float GetTime(int ClientID);
+};
+
+#endif
+


### PR DESCRIPTION
this commit isnt really nice but i think a good base to work on... btw... pickup resetting in race works again and it is possible to play fastcap again.

it is like this now:

```
                       gamecontroller
                             |
                       race interface
                        |          |
                 team race        no team race
                     |             |        |
                  hprace         race     fastcap
```

some of the code should be moved to remove redundancy i guess. also some data is there twice like the race state for the team and extra for each player in the team. is this useful?
